### PR TITLE
G722 is reporting as 8kHz, while its actual 16kHz (RFC 3551 4.5.2)

### DIFF
--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -118,7 +118,7 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 		return SWITCH_STATUS_FALSE;
 	}
 
-	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.samples_per_second : read_impl.actual_samples_per_second;
+	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.actual_samples_per_second : read_impl.samples_per_second;
 
 	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, &pUserData)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error initializing google speech session.\n");

--- a/modules/mod_google_transcribe/mod_google_transcribe.c
+++ b/modules/mod_google_transcribe/mod_google_transcribe.c
@@ -105,6 +105,7 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 	switch_status_t status;
 	switch_codec_implementation_t read_impl = { 0 };
 	void *pUserData;
+	uint32_t samples_per_second;
 
 	if (switch_channel_get_private(channel, MY_BUG_NAME)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_DEBUG, "removing bug from previous transcribe\n");
@@ -117,8 +118,9 @@ static switch_status_t start_capture(switch_core_session_t *session, switch_medi
 		return SWITCH_STATUS_FALSE;
 	}
 
-	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, 
-		read_impl.samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, &pUserData)) {
+	samples_per_second = !strcasecmp(read_impl.iananame, "g722") ? read_impl.samples_per_second : read_impl.actual_samples_per_second;
+
+	if (SWITCH_STATUS_FALSE == google_speech_session_init(session, responseHandler, samples_per_second, flags & SMBF_STEREO ? 2 : 1, lang, interim, &pUserData)) {
 		switch_log_printf(SWITCH_CHANNEL_LOG, SWITCH_LOG_ERROR, "Error initializing google speech session.\n");
 		return SWITCH_STATUS_FALSE;
 	}


### PR DESCRIPTION
If we try to resample G722, I did not get it to work correctly. Then I found the issue with G722 and its wrong rate. I do a simple check for G722, and then return the "actual_samples_per_second".