### PR TITLE
fix for mod_awstranscript tocompile properly in FS

### DIFF
--- a/modules/mod_aws_transcribe/Makefile.am
+++ b/modules/mod_aws_transcribe/Makefile.am
@@ -4,7 +4,7 @@ MODNAME=mod_aws_transcribe
 mod_LTLIBRARIES = mod_aws_transcribe.la
 mod_aws_transcribe_la_SOURCES  = mod_aws_transcribe.c aws_transcribe_glue.cpp
 mod_aws_transcribe_la_CFLAGS   = $(AM_CFLAGS)
-mod_aws_transcribe_la_CXXFLAGS = $(AM_CXXFLAGS) -std=c++11 -I${switch_srcdir}/libs/aws-sdk-cpp/aws-cpp-sdk-core/include -I${switch_srcdir}/libs/aws-sdk-cpp/aws-cpp-sdk-transcribe/include -I${switch_srcdir}/libs/aws-sdk-cpp/build/.deps/install/include
+mod_aws_transcribe_la_CXXFLAGS = $(AM_CXXFLAGS) -std=c++11 -I${switch_srcdir}/libs/aws-sdk-cpp/aws-cpp-sdk-core/include -I${switch_srcdir}/libs/aws-sdk-cpp/aws-cpp-sdk-transcribestreaming/include -I${switch_srcdir}/libs/aws-sdk-cpp/build/.deps/install/include
 
 mod_aws_transcribe_la_LIBADD   = $(switch_builddir)/libfreeswitch.la
 mod_aws_transcribe_la_LDFLAGS  = -avoid-version -module -no-undefined -L${switch_srcdir}/libs/aws-sdk-cpp/build/.deps/install/lib -L${switch_srcdir}/libs/aws-sdk-cpp/build/aws-cpp-sdk-core -L${switch_srcdir}/libs/aws-sdk-cpp/build/aws-cpp-sdk-transcribestreaming -laws-cpp-sdk-transcribestreaming -laws-cpp-sdk-core -laws-c-event-stream -laws-checksums -laws-c-common -lpthread -lcurl -lcrypto -lssl -lz


### PR DESCRIPTION
Fixed name of folder. Without this you will see the following error when making freeswitch

making all mod_aws_transcribe
make[4]: Entering directory '/usr/local/src/freeswitch/src/mod/applications/mod_aws_transcribe'
  CXX      mod_aws_transcribe_la-aws_transcribe_glue.lo
aws_transcribe_glue.cpp:19:10: fatal error: aws/transcribestreaming/TranscribeStreamingServiceClient.h: No such file or directory
 #include <aws/transcribestreaming/TranscribeStreamingServiceClient.h>
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
Makefile:760: recipe for target 'mod_aws_transcribe_la-aws_transcribe_glue.lo' failed
make[4]: *** [mod_aws_transcribe_la-aws_transcribe_glue.lo] Error 1
make[4]: Leaving directory '/usr/local/src/freeswitch/src/mod/applications/mod_aws_transcribe'
Makefile:705: recipe for target 'mod_aws_transcribe-all' failed
make[3]: *** [mod_aws_transcribe-all] Error 1
make[3]: Leaving directory '/usr/local/src/freeswitch/src/mod'
Makefile:611: recipe for target 'all-recursive' failed
make[2]: *** [all-recursive] Error 1
make[2]: Leaving directory '/usr/local/src/freeswitch/src'
Makefile:5370: recipe for target 'all-recursive' failed
make[1]: *** [all-recursive] Error 1
make[1]: Leaving directory '/usr/local/src/freeswitch'
Makefile:1584: recipe for target 'all' failed
make: *** [all] Error 2