### PR TITLE
Update docs and example WSS protocol 

### DIFF
--- a/examples/ws_server.js
+++ b/examples/ws_server.js
@@ -7,28 +7,27 @@ let wstream;
 
 console.log(`listening on port ${port}, writing incoming raw audio to file ${recordingPath}`);
 
-const wss = new WebSocket.Server({ 
-  port,
-  handleProtocols: (protocols, req) => {
-    return 'audiostream.drachtio.org';
-  }
+const wss = new WebSocket.Server({
+    port,
+    handleProtocols: (protocols, req) => {
+        return 'audio.drachtio.org';
+    }
 });
- 
+
 wss.on('connection', (ws, req) => {
-  console.log(`received connection from ${req.connection.remoteAddress}`);
-  wstream = fs.createWriteStream(recordingPath);
+    console.log(`received connection from ${req.connection.remoteAddress}`);
+    wstream = fs.createWriteStream(recordingPath);
 
-  ws.on('message',  (message) => {
-    if (typeof message === 'string') {
-      console.log(`received message: ${message}`);
-    }
-    else if (message instanceof Buffer) {
-      wstream.write(message);
-    }
-  });
+    ws.on('message', (message) => {
+        if (typeof message === 'string') {
+            console.log(`received message: ${message}`);
+        } else if (message instanceof Buffer) {
+            wstream.write(message);
+        }
+    });
 
-  ws.on('close', (code, reason) => {
-    console.log(`socket closed ${code}:${reason}`);
-    wstream.end();
-  });
+    ws.on('close', (code, reason) => {
+        console.log(`socket closed ${code}:${reason}`);
+        wstream.end();
+    });
 });

--- a/modules/mod_audio_fork/README.md
+++ b/modules/mod_audio_fork/README.md
@@ -3,7 +3,7 @@
 A Freeswitch module that attaches a bug to a media server endpoint and streams L16 audio via websockets to a remote server.  This module also supports receiving media from the server to play back to the caller, enabling the creation of full-fledged IVR or dialog-type applications.
 
 #### Environment variables
-- MOD_AUDIO_FORK_SUBPROTOCOL_NAME - optional, name of the [websocket sub-protocol](https://tools.ietf.org/html/rfc6455#section-1.9) to advertise; defaults to "audiostream.drachtio.org"
+- MOD_AUDIO_FORK_SUBPROTOCOL_NAME - optional, name of the [websocket sub-protocol](https://tools.ietf.org/html/rfc6455#section-1.9) to advertise; defaults to "audio.drachtio.org"
 - MOD_AUDIO_FORK_SERVICE_THREADS - optional, number of libwebsocket service threads to create; these threads handling sending all messages for all sessions.  Defaults to 1, but can be set to as many as 5.
 
 ## API


### PR DESCRIPTION
The readme & example for mod_audio_fork module indicate the WS protocol will be audiostream.drachtio.org, but the module itself is using audio.drachtio.org.  I figured its least disruptive to modify the example and docs than the module itself which may be in use in many places.  Let me know if you'd prefer an alternative fix and thanks for the amazing project!