### PR TITLE
fix crash on reload

### DIFF
--- a/modules/mod_audio_fork/audio_pipe.cpp
+++ b/modules/mod_audio_fork/audio_pipe.cpp
@@ -373,7 +373,7 @@ bool AudioPipe::lws_service_thread(unsigned int nServiceThread) {
   info.ws_ping_pong_interval = 20;      // interval in seconds between sending PINGs on idle websocket connections
   info.timeout_secs_ah_idle = 10;       // secs to allow a client to hold an ah without using it
 
-  lwsl_notice("AudioPipe::lws_service_thread creating context in service thread %d..\n", nServiceThread); 
+  lwsl_notice("AudioPipe::lws_service_thread creating context in service thread %d.\n", nServiceThread);
 
   contexts[nServiceThread] = lws_create_context(&info);
   if (!contexts[nServiceThread]) {
@@ -406,21 +406,26 @@ void AudioPipe::initialize(const char* protocol, unsigned int nThreads, int logl
   lws_initialized = true;
 }
 
-void AudioPipe::deinitialize() {
+bool AudioPipe::deinitialize() {
   assert(lws_initialized);
   lwsl_notice("AudioPipe::deinitialize\n"); 
   lws_stopping = true;
   lws_initialized = false;
   do
   {
+    lwsl_notice("waiting for pending connects to complete\n");
+  } while (pendingConnects.size() > 0);
+  do
+  {
     lwsl_notice("waiting for disconnects to complete\n");
   } while (pendingDisconnects.size() > 0);
 
-  for (unsigned int i = 0; i < numContexts; i)
+  for (unsigned int i = 0; i < numContexts; i++)
   {
     lwsl_notice("AudioPipe::deinitialize destroying context %d of %d\n", i + 1, numContexts);
     lws_context_destroy(contexts[i]);
   }
+  return true;
 }
 
 // instance members

--- a/modules/mod_audio_fork/audio_pipe.hpp
+++ b/modules/mod_audio_fork/audio_pipe.hpp
@@ -34,7 +34,7 @@ public:
   };
 
   static void initialize(const char* protocolName, unsigned int nThreads, int loglevel, log_emit_function logger);
-  static void deinitialize();
+  static bool deinitialize();
   static bool lws_service_thread(unsigned int nServiceThread);
 
   // constructor

--- a/modules/mod_audio_fork/lws_glue.cpp
+++ b/modules/mod_audio_fork/lws_glue.cpp
@@ -375,8 +375,12 @@ extern "C" {
   }
 
   switch_status_t fork_cleanup() {
-    AudioPipe::deinitialize();
-    return SWITCH_STATUS_SUCCESS;
+    bool cleanup = false;
+    cleanup = AudioPipe::deinitialize();
+    if (cleanup == true) {
+        return SWITCH_STATUS_SUCCESS;
+    }
+    return SWITCH_STATUS_FALSE;
   }
 
   switch_status_t fork_session_init(switch_core_session_t *session, 


### PR DESCRIPTION
- wait for pending connections to complete before unloading module
- fix for loop on destroying contexts
- return bool to `fork_cleanup()`